### PR TITLE
more info in thrown error

### DIFF
--- a/native-compiler.js
+++ b/native-compiler.js
@@ -79,7 +79,7 @@ function runCompile(ast) {
     codeFile.removeCallback();
     
     if (cAst.Functions.length !== 1) {
-        throw new ParseError('C code snippet contained wrong amount of functions.');
+        throw new ParseError('C code snippet contained wrong amount of functions. - ' + code);
     }
     
     const cFunc = cAst.Functions[0];


### PR DESCRIPTION
The order in which natives is done isn't apparent, and there's no output as to which .md file failed