### PR TITLE
tweak(worker): give more information on what file it failed on

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -20,6 +20,6 @@ module.exports = (input, cb) => {
 
         cb(null, nativeData);
     } catch (e) {
-        cb(e.toString());
+        cb(`Failed on ${input} with error ${e.toString()}`);
     }
 };


### PR DESCRIPTION
Currently its not easy to tell which file the native gen is failing on, this prints out the file path on failure.